### PR TITLE
Update import path of github_flavored_markdown package.

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/goincremental/negroni-oauth2"
 	"github.com/goincremental/negroni-sessions"
 	"github.com/gorilla/mux"
-	"github.com/shurcooL/go/github_flavored_markdown"
+	"github.com/shurcooL/github_flavored_markdown"
 )
 
 type config struct {


### PR DESCRIPTION
It has moved out into a standalone repo recently. See https://github.com/shurcooL/go/issues/19#issuecomment-102574426 for rationale.

I see this repo uses godep for vendoring, so you'll likely want to update that also.
